### PR TITLE
fix: 터미널 크기 조절 시, parent element 의 크기를 기준으로 계산

### DIFF
--- a/src/Components/Terminal.js
+++ b/src/Components/Terminal.js
@@ -12,7 +12,7 @@ export function Terminal() {
           <FontAwesomeIcon icon={faPlay} color="#00912c" />
         </span>
       </div>
-      <div className="content-wrapper">
+      <div className="terminal-wrapper">
         <TerminalMenu />
       </div>
     </div>

--- a/src/Components/TerminalMenu.js
+++ b/src/Components/TerminalMenu.js
@@ -14,14 +14,13 @@ export function TerminalMenu() {
   let token = localStorage.getItem("access_token");
 
   // xterm Terminal
-  // FitAddon: xtermRef 를 부모 요소 크기에 맞게 조정
   let xtermRef = useRef();
+  let terminalWrapper = useRef();
+  // FitAddon: xtermRef 를 부모 요소 크기에 맞게 조정
   const fitAddon = new FitAddon();
   // Terminal options
   let [ptyCols, setPtyCols] = useState(0);
   let [ptyRows, setPtyRows] = useState(0);
-  let [width, setWidth] = useState("0");
-  let [height, setHeight] = useState("0");
   const xtermOptions = {
     cursorBlink: true,
     theme: {
@@ -32,6 +31,7 @@ export function TerminalMenu() {
 
   let sshClient = useRef();
   useEffect(() => {
+    terminalWrapper.current = document.getElementsByClassName('terminal-wrapper')[0];
     window.onresize = resizeTerminal;
     fitAddon.fit();
 
@@ -48,23 +48,6 @@ export function TerminalMenu() {
     sshClient.current.on("SSH_RELAY", (data) => {
       xtermRef.current.terminal.write(decodeText(data));
     });
-    xtermRef.current.terminal.writeln("Hello, World!!!");
-    xtermRef.current.terminal.writeln("Hello, World!");
-    xtermRef.current.terminal.writeln("Hello, World!");
-    xtermRef.current.terminal.writeln("Hello, World!");
-    xtermRef.current.terminal.writeln("Hello, World!");
-    xtermRef.current.terminal.writeln("Hello, World!");
-    xtermRef.current.terminal.writeln("Hello, World!");
-    xtermRef.current.terminal.writeln("Hello, World!");
-    xtermRef.current.terminal.writeln("Hello, World!");
-    xtermRef.current.terminal.writeln("Hello, World!");
-    xtermRef.current.terminal.writeln("Hello, World!");
-    xtermRef.current.terminal.writeln("Hello, World!");
-    xtermRef.current.terminal.writeln("Hello, World!");
-    xtermRef.current.terminal.writeln("Hello, World!");
-    xtermRef.current.terminal.writeln("Hello, World!");
-    xtermRef.current.terminal.writeln("Hello, World!!!!!!!!!!!!!!!");
-
   }, []);
 
   /**
@@ -108,12 +91,12 @@ export function TerminalMenu() {
 
     // 새로운 pty 크기 계산
     let cols = parseInt(
-      window.innerWidth /
+      terminalWrapper.current.clientWidth /
         xtermRef.current.terminal._core._renderService._renderer.dimensions
           .actualCellWidth
     );
     let rows = parseInt(
-      window.innerHeight /
+      terminalWrapper.current.clientHeight /
         xtermRef.current.terminal._core._renderService._renderer.dimensions
           .actualCellHeight
     );


### PR DESCRIPTION
Fix #1 

- 터미널 창 wrapper 요소 클래스 명 변경
    `content-wrapper` -> `terminal-wrapper`
- 불필요한 states 및 디버그용 코드 제거
- 터미널 크기 조절 시, parent element (`terminal-wrapper` 의 크기를 기준으로 계산