### PR TITLE
update: 컨테이너 생성 요청, SSH 연결 샘플

### DIFF
--- a/src/Components/TerminalMenu.js
+++ b/src/Components/TerminalMenu.js
@@ -1,8 +1,12 @@
+import axios from "axios";
 import { useRef, useEffect, useState } from "react";
 import { SSHClient } from "../utils/websocket";
 import { XTerm } from "xterm-for-react";
 import { FitAddon } from "xterm-addon-fit";
 import "xterm/css/xterm.css";
+import {API_URL, RUNTIME_BRIDGE_URL} from "../constants";
+
+
 
 /**
  * 터미널 메뉴
@@ -31,24 +35,16 @@ export function TerminalMenu() {
 
   let sshClient = useRef();
   useEffect(() => {
+    initTerminal();
+  }, []);
+
+  let initTerminal= () => {
+    // xterm 초기화
     terminalWrapper.current = document.getElementsByClassName('terminal-wrapper')[0];
     window.onresize = resizeTerminal;
     fitAddon.fit();
+  }
 
-    // FIXME Bridge 서버로부터 컨테이너 URL 을 받아서 사용
-    sshClient.current = new SSHClient("http://127.0.0.1:8000/", token);
-
-    sshClient.current.on("AUTHENTICATE", (data) => {
-      if (data === "AUTHENTICATE") {
-        sshClient.current.emit("SSH_CONNECT", "SSH_CONNECT");
-      }
-    });
-
-    // 'SSH' 이벤트로 보낸 입력값을 되돌려 받고, 이를 터미널에 보여줍니다.
-    sshClient.current.on("SSH_RELAY", (data) => {
-      xtermRef.current.terminal.write(decodeText(data));
-    });
-  }, []);
 
   /**
    * SSH 서버에 보내기 전, 데이터를 인코딩
@@ -119,8 +115,50 @@ export function TerminalMenu() {
     }
   };
 
+  /**
+   * SSH relay 서버 연결
+   * 코드 실행 환경을 생성하도록 브릿지 서버에 요청을 보냅니다.
+   */
+  async function initRuntime(mock=false) {
+    let contInfo = {}
+
+    // FIXME headers, payload 를 상황에 맞게 보내줘야 함
+    let headers = {Authorization: "Bearer " + localStorage.getItem("access_token") || ""}
+    let payload = {
+      name: "C (gcc11)",
+      lang: "C",
+    }
+    let res = await axios.post(`${RUNTIME_BRIDGE_URL}/api/containers/launch`, payload, {headers})
+    contInfo.url = res.data.url;
+    contInfo.port = res.data.port;
+
+    if (!contInfo.url || !contInfo.port) {
+      return;
+    }
+    sshClient.current = new SSHClient(`${contInfo.url}:${contInfo.port}`, token);
+
+    // 웹소켓 연결 상태에서 추가적인 인증 정보를 전송합니다.
+    sshClient.current.on("AUTHENTICATE", (data) => {
+      if (data === "AUTHENTICATE") {
+        sshClient.current.emit("SSH_CONNECT", "SSH_CONNECT");
+      }
+    });
+
+    // 'SSH' 이벤트로 보낸 입력값을 되돌려 받고, 이를 터미널에 보여줍니다.
+    sshClient.current.on("SSH_RELAY", (data) => {
+      xtermRef.current.terminal.write(decodeText(data));
+    });
+  }
+
+
   return (
     <>
+      <button onClick={initRuntime}>
+        [임시] 컨테이너 시작하기
+      </button>
+      <button onClick={_ => initRuntime(true)}>
+        [임시] "로컬" SSH 연결
+      </button>
       <XTerm
         ref={xtermRef}
         className={"xterm-terminal"}

--- a/src/Components/TerminalMenu.js
+++ b/src/Components/TerminalMenu.js
@@ -119,7 +119,7 @@ export function TerminalMenu() {
    * SSH relay 서버 연결
    * 코드 실행 환경을 생성하도록 브릿지 서버에 요청을 보냅니다.
    */
-  async function initRuntime(mock=false) {
+  async function initRuntime() {
     let contInfo = {}
 
     // FIXME headers, payload 를 상황에 맞게 보내줘야 함
@@ -155,9 +155,6 @@ export function TerminalMenu() {
     <>
       <button onClick={initRuntime}>
         [임시] 컨테이너 시작하기
-      </button>
-      <button onClick={_ => initRuntime(true)}>
-        [임시] "로컬" SSH 연결
       </button>
       <XTerm
         ref={xtermRef}

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,7 @@
 // FIXME 이 파일은 git 을 통해 공유되므로, 중요 인증 정보들은 다른 방식으로 불러와야 합니다.
 //  dev/prod 환경에 따라 설정을 나눌 수 있으면 좋을 것 같습니다.
 
+const DEBUG = true
+
 export const API_URL = 'http://api.together-coding.com'
-export const RUNTIME_BRIDGE_URL = 'https://bridge.together-coding.com'
+export const RUNTIME_BRIDGE_URL = DEBUG ? 'http://localhost:8080' : 'https://bridge.together-coding.com'


### PR DESCRIPTION
# 수정 사항
![image](https://user-images.githubusercontent.com/48249622/165823105-7394eb58-e100-4c05-87a8-b5ea6ee7d482.png)

이전에는 IDE 페이지 접속 시, 바로 SSH 연결을 시도하도록 되어 있었습니다.
수정본에서는, 바로 연결하지 않도록 하였습니다.

대신, 임시로 만들어 둔 버튼을 클릭할 때
1. [Runtime Bridge](https://github.com/Together-Coding/runtime-bridge) 에 컨테이너 생성 요청을 보내고
2. 새로 생성된 컨테이너에 대한 정보를 받으면
3. 해당 연결 정보를 이용하여 [Runtime Agent](https://github.com/Together-Coding/runtime-agent) (컨테이너 상 서버) 를 통하여 SSH 를 연결합니다.

# 처리 필요 부분
1.  
  https://github.com/Together-Coding/IDE-sample/blob/18d0e2e7ca91de2f9734b1f8dd06c1ccafba3878/src/constants.js#L4-L7
  이와같은 부분들은, 프로젝트 전체의 구조나 코드 스타일에 따라서 수정해주시면 좋을 것 같습니다. 특히, `DEBUG` 값은 개발/배포 시 설정하기 쉽도록 만든다면 좋을 것 같습니다.

2. 아직 Runtime Bridge 서버는 배포가 되지 않은 상태입니다. 주말 내로 배포가 될 예정이고, 이후부터는 직접 터미널을 사용하면서 테스트를 할 수도 있습니다.