### PR TITLE
fix: update dev bridge url

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -4,4 +4,4 @@
 const DEBUG = true
 
 export const API_URL = 'http://api.together-coding.com'
-export const RUNTIME_BRIDGE_URL = DEBUG ? 'http://localhost:8080' : 'https://bridge.together-coding.com'
+export const RUNTIME_BRIDGE_URL = DEBUG ? 'https://dev-bridge.together-coding.com' : 'https://bridge.together-coding.com'


### PR DESCRIPTION
안녕하세요.

터미널을 이용할 때, 컨테이너 생성을 요청 할 Runtime Bridge 서버의 개발 서버가 배포되었습니다.
API 문서는 [Bridge API](https://dev-bridge.together-coding.com/swagger/index.html), [유저 플로우](https://www.notion.so/cse-capstone/Runtime-c40c74f365f74a2bad62aa2c420f9555) 에서 확인하실 수 있습니다.

익숙하지 않은 golang && 처음 쓰는 프레임워크([gin-gonic](https://gin-gonic.com/docs/)) 이라서, 문서도 서버도 좀 엉성할 것 같습니다.

뭔가 이상하게 동작하거나, 문제가 있다면 디스코드 부탁드립니다.

감사합니다.